### PR TITLE
Allow for passing custom http client for azuredevops and git client

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -72,6 +72,20 @@ func NewClient(connection *Connection, baseUrl string) *Client {
 	}
 }
 
+func NewClientWithOptions(connection *Connection, baseUrl string, options ...ClientOptionFunc) *Client {
+	c := NewClient(connection, baseUrl)
+
+	// Apply any given client options.
+	for _, fn := range options {
+		if fn == nil {
+			continue
+		}
+		fn(c)
+	}
+
+	return c
+}
+
 type Client struct {
 	baseUrl                 string
 	client                  *http.Client

--- a/azuredevops/client_options.go
+++ b/azuredevops/client_options.go
@@ -1,0 +1,13 @@
+package azuredevops
+
+import "net/http"
+
+// ClientOptionFunc can be used customize a new AzureDevops API client.
+type ClientOptionFunc func(*Client)
+
+// WithHTTPClient can be used to configure a custom HTTP client.
+func WithHTTPClient(httpClient *http.Client) ClientOptionFunc {
+	return func(c *Client) {
+		c.client = httpClient
+	}
+}

--- a/azuredevops/git/client.go
+++ b/azuredevops/git/client.go
@@ -274,6 +274,25 @@ func NewClient(ctx context.Context, connection *azuredevops.Connection) (Client,
 	}, nil
 }
 
+func NewClientWithOptions(ctx context.Context, connection *azuredevops.Connection, options ...azuredevops.ClientOptionFunc) (Client, error) {
+	client, err := connection.GetClientByResourceAreaId(ctx, ResourceAreaId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply any given client options.
+	for _, fn := range options {
+		if fn == nil {
+			continue
+		}
+		fn(client)
+	}
+
+	return &ClientImpl{
+		Client: *client,
+	}, nil
+}
+
 // [Preview API] Create an annotated tag.
 func (client *ClientImpl) CreateAnnotatedTag(ctx context.Context, args CreateAnnotatedTagArgs) (*GitAnnotatedTag, error) {
 	if args.TagObject == nil {


### PR DESCRIPTION
Current implementation of Azure DevOps go client does not allow for using custom Go client. This provides basic implementation (passing http client only to `git` area for now).