### PR TITLE
Allow custom HTTP client for Connection

### DIFF
--- a/azuredevops/client.go
+++ b/azuredevops/client.go
@@ -53,12 +53,17 @@ var baseUserAgent = "go/" + runtime.Version() + " (" + runtime.GOOS + " " + runt
 // NewClient provides an Azure DevOps client
 // and copies the TLS config and timeout from the supplied connection
 func NewClient(connection *Connection, baseUrl string) *Client {
-	httpClient := &http.Client{}
-	if connection.TlsConfig != nil {
-		httpClient.Transport = &http.Transport{TLSClientConfig: connection.TlsConfig}
-	}
-	if connection.Timeout != nil {
-		httpClient.Timeout = *connection.Timeout
+	var httpClient *http.Client
+	if connection.httpClient != nil {
+		httpClient = connection.httpClient
+	} else {
+		httpClient = &http.Client{}
+		if connection.TlsConfig != nil {
+			httpClient.Transport = &http.Transport{TLSClientConfig: connection.TlsConfig}
+		}
+		if connection.Timeout != nil {
+			httpClient.Timeout = *connection.Timeout
+		}
 	}
 
 	return NewClientWithOptions(connection, baseUrl, WithHTTPClient(httpClient))

--- a/azuredevops/connection_options.go
+++ b/azuredevops/connection_options.go
@@ -1,0 +1,20 @@
+package azuredevops
+
+import "net/http"
+
+type ConnectionOptionFunc func(*Connection)
+
+// WithConnectionHTTPClient sets the HTTP client that will be used by the connection.
+func WithConnectionHTTPClient(client *http.Client) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.httpClient = client
+	}
+}
+
+// WithConnectionPersonalAccessToken specifies the PAT to use for authentication with Azure DevOps.
+func WithConnectionPersonalAccessToken(personalAccessToken string) ConnectionOptionFunc {
+	return func(c *Connection) {
+		authorizationString := CreateBasicAuthHeaderValue("", personalAccessToken)
+		c.AuthorizationString = authorizationString
+	}
+}


### PR DESCRIPTION
I've added the ability to specify a custom HTTP client when creating a Connection. This is important because the various Azure DevOps clients make requests during construction to get the resource area info. This meant that some requests would be made with the default HTTP client even when specifying a custom one for the git client.